### PR TITLE
use cjs

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,3 @@
-// If you remove/comment out this import to avoid ESM importing `.ts` file, then the example will work!
-import './foo.ts';
+// @ts-ignore
+require('./foo');
 console.log('load config.ts');

--- a/foo.ts
+++ b/foo.ts
@@ -1,1 +1,2 @@
-console.log('foo loaded');
+const a: number = 1;
+console.log('foo loaded', a);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "test",
   "version": "1.0.0",
   "description": "",
-  "type": "module",
+  "type": "commonjs",
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/test.cjs
+++ b/test.cjs
@@ -1,9 +1,9 @@
 const { join } = require('node:path');
-const { cosmiconfig } = require('cosmiconfig');
 
 async function main() {
-  const explorer = cosmiconfig('@acme/test');
-  explorer.load(join(__dirname, 'config.ts'));
+  // Using require works when running with `npx ts-node test.cjs`
+  // `node test.cjs` won't work still obviously
+  require('./config.ts');
 }
 
 main();


### PR DESCRIPTION
use cjs so the config fill loads via `require` if you use `npx ts-node test.cjs`