### PR TITLE
remove cosmiconfig from ESM example

### DIFF
--- a/test.cjs
+++ b/test.cjs
@@ -1,9 +1,5 @@
-const { join } = require('node:path');
-const { cosmiconfig } = require('cosmiconfig');
-
 async function main() {
-  const explorer = cosmiconfig('@acme/test');
-  explorer.load(join(__dirname, 'config.ts'));
+  await import('./config.ts');
 }
 
 main();


### PR DESCRIPTION
Remove `cosmiconfig` and use `import()` to import ESM module to show it's just a general Node + ESM + TS issue.